### PR TITLE
fix: allow users to access 1:1 DMs without requiring them in the store

### DIFF
--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -172,7 +172,15 @@ export class DeletionStore {
             return this.calculatedPermissions[channelId];
         }
 
-        const canViewChannel = Vencord.Webpack.Common.PermissionStore.can(0x400n, Vencord.Webpack.Common.ChannelStore.getChannel(channelId));
+        const channel = Vencord.Webpack.Common.ChannelStore.getChannel(channelId);
+        
+        // Always allow access to 1:1 DM channels (type 1)
+        if (channel && channel.type === 1) {
+            this.calculatedPermissions[channelId] = true;
+            return true;
+        }
+
+        const canViewChannel = Vencord.Webpack.Common.PermissionStore.can(0x400n, channel);
 
         this.calculatedPermissions[channelId] = canViewChannel;
         

--- a/tampermonkey.config.json
+++ b/tampermonkey.config.json
@@ -1,7 +1,7 @@
 {
   "name": "DiscorchDeleter",
   "namespace": "https://discord.com/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A script to delete all messages provided from Discorch",
   "author": "DarkerInk",
   "match": [


### PR DESCRIPTION
Users should always have access to their direct messages regardless of whether they're currently loaded in the store. This patch ensures 1:1 DM channels (type 1) are always accessible during the deletion process.